### PR TITLE
Remove concurrent enumeration in search filtering

### DIFF
--- a/TODocumentPickerViewController/Models/TODocumentPickerItemManager.m
+++ b/TODocumentPickerViewController/Models/TODocumentPickerItemManager.m
@@ -102,7 +102,7 @@
 - (NSArray *)filteredItemsWithItems:(NSArray *)items searchString:(NSString *)searchString
 {
     NSMutableArray *filteredItems = [NSMutableArray array];
-    [items enumerateObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(TODocumentPickerItem *item, NSUInteger i, BOOL *stop) {
+    [items enumerateObjectsUsingBlock:^(TODocumentPickerItem *item, NSUInteger i, BOOL *stop) {
         if ([item.fileName rangeOfString:searchString options:(NSCaseInsensitiveSearch|NSDiacriticInsensitiveSearch)].location != NSNotFound) {
             [filteredItems addObject:item];
         }


### PR DESCRIPTION
From what I understand, the concurrent enumeration flag was added to speed cup the search filtering logic, but I'm seeing various threading issues caused by this in simple search scenarios (in the Example demo).

<img width="1549" alt="image" src="https://user-images.githubusercontent.com/241156/39253390-0793568e-48a8-11e8-9031-b4e75cf3e44e.png">
